### PR TITLE
Use Exception.message to retrieve error message

### DIFF
--- a/lib/hush/resolver.ex
+++ b/lib/hush/resolver.ex
@@ -105,7 +105,7 @@ defmodule Hush.Resolver do
         try do
           Provider.fetch(provider, key)
         rescue
-          error -> {:error, error.message}
+          error -> {:error, Exception.message(error)}
         end
 
       cached ->

--- a/lib/hush/transformer.ex
+++ b/lib/hush/transformer.ex
@@ -20,7 +20,7 @@ defmodule Hush.Transformer do
       Enum.reduce(transformers(), {:ok, value}, reducer!(options))
     rescue
       error ->
-        {:error, error.message}
+        {:error, Exception.message(error)}
     end
   end
 

--- a/lib/hush/transformer/cast.ex
+++ b/lib/hush/transformer/cast.ex
@@ -15,7 +15,7 @@ defmodule Hush.Transformer.Cast do
     try do
       {:ok, to!(type, value)}
     rescue
-      error -> {:error, "Couldn't cast to type #{type} due to #{error.message}"}
+      error -> {:error, "Couldn't cast to type #{type} due to #{Exception.message(error)}"}
     end
   end
 


### PR DESCRIPTION
While most of the time elixir errors have `message` field, this isn't a requirement. Good thing is that implementing `message/1` callback _is_ a requirement, so we can use `Exception.message/1`